### PR TITLE
Fix missing Page method definitions

### DIFF
--- a/include/storage/page.h
+++ b/include/storage/page.h
@@ -14,20 +14,33 @@ class Page {
 public:
     using PageID = uint64_t;
 
-    Page(PageID id);
+    Page(PageID id) : id_(id), dirty_(false) {
+        std::memset(buffer_, 0, PAGE_SIZE);
+    }
 
     // Accessors
-    PageID get_id() const;
-    const uint8_t* data() const;
-    uint8_t* data();
+    PageID get_id() const { return id_; }
+    const uint8_t* data() const { return buffer_; }
+    uint8_t* data() { return buffer_; }
 
     // Metadata
-    bool is_dirty() const;
-    void mark_dirty(bool dirty);
+    bool is_dirty() const { return dirty_; }
+    void mark_dirty(bool dirty) { dirty_ = dirty; }
 
     // Serialization
-    void from_bytes(const uint8_t* src);
-    void to_bytes(uint8_t* dest) const;
+    void from_bytes(const uint8_t* src) {
+        if (src == nullptr) {
+            throw std::invalid_argument("src buffer is null");
+        }
+        std::memcpy(buffer_, src, PAGE_SIZE);
+        dirty_ = false;
+    }
+    void to_bytes(uint8_t* dest) const {
+        if (dest == nullptr) {
+            throw std::invalid_argument("dest buffer is null");
+        }
+        std::memcpy(dest, buffer_, PAGE_SIZE);
+    }
 
 private:
     PageID id_;

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,19 @@
+#include "include/storage/page.h"
+#include <iostream>
+
+int main() {
+    alpha::storage::Page page(1);
+    uint8_t buffer[alpha::storage::PAGE_SIZE];
+    for (size_t i = 0; i < alpha::storage::PAGE_SIZE; ++i) {
+        buffer[i] = static_cast<uint8_t>(i % 256);
+    }
+
+    page.from_bytes(buffer);
+
+    uint8_t out[alpha::storage::PAGE_SIZE];
+    page.to_bytes(out);
+
+    bool ok = std::memcmp(buffer, out, alpha::storage::PAGE_SIZE) == 0;
+    std::cout << (ok ? "OK" : "FAIL") << std::endl;
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- implement `Page` class methods directly in header
- add a sample `main.cpp` usage example to verify functionality

## Testing
- `g++ -std=c++17 main.cpp -o test`
- `./test`

------
https://chatgpt.com/codex/tasks/task_e_68777fcaf0cc8321a9016d582160c8ec