### PR TITLE
Add minimal SQL tokenizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore build artifacts
+*.o
+db

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC ?= gcc
 CFLAGS ?= -Wall -Wextra -std=c11 -Iinclude
 
-SRC := $(wildcard src/*.c src/storage/*.c)
+SRC := $(wildcard src/*.c src/storage/*.c src/parser/*.c)
 OBJ := $(SRC:.c=.o)
 TARGET := db
 

--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ make
 ./db
 ```
 
-The executable demonstrates basic usage of the `Page` structure.
+The executable demonstrates basic usage of the `Page` structure and a very
+simple SQL tokenizer found in `parser/`.

--- a/include/parser/parser.h
+++ b/include/parser/parser.h
@@ -1,0 +1,50 @@
+#ifndef PARSER_PARSER_H
+#define PARSER_PARSER_H
+
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Token types for a very small subset of SQL */
+typedef enum TokenType {
+    TOKEN_EOF,
+    TOKEN_IDENTIFIER,
+    TOKEN_NUMBER,
+    TOKEN_STAR,
+    TOKEN_COMMA,
+    TOKEN_SEMICOLON,
+    TOKEN_LPAREN,
+    TOKEN_RPAREN,
+    TOKEN_STRING,
+    TOKEN_KEYWORD_SELECT,
+    TOKEN_KEYWORD_INSERT,
+    TOKEN_KEYWORD_INTO,
+    TOKEN_KEYWORD_VALUES,
+    TOKEN_UNKNOWN
+} TokenType;
+
+typedef struct Token {
+    TokenType type;
+    const char *start;
+    size_t length;
+} Token;
+
+typedef struct Parser {
+    const char *input;
+    const char *current;
+} Parser;
+
+/* Initialize the parser with an input string */
+void parser_init(Parser *parser, const char *input);
+
+/* Obtain the next token from the input */
+Token parser_next_token(Parser *parser);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PARSER_PARSER_H */

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include "storage/page.h"
+#include "parser/parser.h"
 
 int main(void)
 {
@@ -17,6 +18,19 @@ int main(void)
     printf("Page ID: %llu\n", (unsigned long long)page_get_id(&page));
     printf("Dirty: %d\n", page_is_dirty(&page));
     printf("Data: %s\n", (char*)buffer);
+
+    /* Demo: simple SQL tokenization */
+    const char *query = "SELECT * FROM table1;";
+    Parser parser;
+    parser_init(&parser, query);
+
+    printf("Tokens:\n");
+    for (;;) {
+        Token tok = parser_next_token(&parser);
+        if (tok.type == TOKEN_EOF)
+            break;
+        printf("  %d: '%.*s'\n", tok.type, (int)tok.length, tok.start);
+    }
 
     return 0;
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -1,0 +1,87 @@
+#include "parser/parser.h"
+#include <ctype.h>
+#include <string.h>
+#include <strings.h>
+
+static bool is_keyword(const char *start, size_t len, const char *kw)
+{
+    return strlen(kw) == len && strncasecmp(start, kw, len) == 0;
+}
+
+void parser_init(Parser *parser, const char *input)
+{
+    parser->input = input ? input : "";
+    parser->current = parser->input;
+}
+
+static void skip_whitespace(Parser *parser)
+{
+    while (isspace((unsigned char)*parser->current))
+        parser->current++;
+}
+
+Token parser_next_token(Parser *parser)
+{
+    skip_whitespace(parser);
+
+    Token token;
+    token.start = parser->current;
+    token.length = 1;
+    token.type = TOKEN_EOF;
+
+    char c = *parser->current;
+    if (c == '\0') {
+        token.type = TOKEN_EOF;
+        return token;
+    }
+
+    parser->current++;
+
+    switch (c) {
+    case '*': token.type = TOKEN_STAR; break;
+    case ',': token.type = TOKEN_COMMA; break;
+    case ';': token.type = TOKEN_SEMICOLON; break;
+    case '(': token.type = TOKEN_LPAREN; break;
+    case ')': token.type = TOKEN_RPAREN; break;
+    case '\'':
+    {
+        /* Parse string literal */
+        token.start = parser->current;
+        while (*parser->current && *parser->current != '\'')
+            parser->current++;
+        token.length = (size_t)(parser->current - token.start);
+        token.type = TOKEN_STRING;
+        if (*parser->current == '\'')
+            parser->current++; /* consume closing quote */
+        return token;
+    }
+    default:
+        if (isalpha((unsigned char)c) || c == '_') {
+            while (isalnum((unsigned char)*parser->current) || *parser->current == '_')
+                parser->current++;
+            token.length = (size_t)(parser->current - token.start);
+            /* Check for keywords */
+            if (is_keyword(token.start, token.length, "SELECT"))
+                token.type = TOKEN_KEYWORD_SELECT;
+            else if (is_keyword(token.start, token.length, "INSERT"))
+                token.type = TOKEN_KEYWORD_INSERT;
+            else if (is_keyword(token.start, token.length, "INTO"))
+                token.type = TOKEN_KEYWORD_INTO;
+            else if (is_keyword(token.start, token.length, "VALUES"))
+                token.type = TOKEN_KEYWORD_VALUES;
+            else
+                token.type = TOKEN_IDENTIFIER;
+            return token;
+        } else if (isdigit((unsigned char)c)) {
+            while (isdigit((unsigned char)*parser->current))
+                parser->current++;
+            token.length = (size_t)(parser->current - token.start);
+            token.type = TOKEN_NUMBER;
+            return token;
+        }
+        token.type = TOKEN_UNKNOWN;
+        return token;
+    }
+
+    return token;
+}


### PR DESCRIPTION
## Summary
- add a simple SQL tokenizer library
- demonstrate tokenization in `main`
- compile parser sources by default
- update README with parser info
- ignore build artifacts

## Testing
- `make clean && make`
- `./db`


------
https://chatgpt.com/codex/tasks/task_e_687798c530188321acfe2049601e227c