### PR TITLE
Add minimal planner, executor, threading and security

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC ?= gcc
-CFLAGS ?= -Wall -Wextra -std=c11 -Iinclude
+CFLAGS ?= -Wall -Wextra -std=c11 -Iinclude -pthread
 
-SRC := $(wildcard src/*.c src/storage/*.c src/parser/*.c)
+SRC := $(wildcard src/*.c src/storage/*.c src/parser/*.c src/planner/*.c src/executor/*.c src/thread/*.c src/security/*.c)
 OBJ := $(SRC:.c=.o)
 TARGET := db
 

--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ make
 ./db
 ```
 
-The executable demonstrates basic usage of the `Page` structure and a very
-simple SQL tokenizer found in `parser/`.
+The executable demonstrates usage of the storage layer, a small SQL tokenizer
+and newly added components including a minimal query planner and executor,
+a thread pool and a simple user authentication module.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,15 +1,20 @@
 # Project Overview
 
 This repository contains a minimal educational database engine written in C.
-The goal is to provide a small code base that illustrates fundamental
-components of a storage engine such as fixed-size pages and a very simple SQL
-parser.
+The code illustrates fundamental components of a storage engine such as
+fixed-size pages and a tiny SQL tokenizer. Additional demonstration modules
+include a small query planner and executor, a basic thread pool and a simple
+user authentication system.
 
 ## Directory Structure
 
 - `src/` - Source files for the demo program.
   - `storage/` - Page abstraction for reading and writing fixed-size buffers.
   - `parser/` - Tiny tokenizer for a subset of SQL.
+  - `planner/` - Very small query planner producing simple plan structures.
+  - `executor/` - Executes query plans over in-memory tables.
+  - `thread/` - Minimal thread pool implementation.
+  - `security/` - Simple user account handling.
 - `include/` - Public headers.
 - `Makefile` - Build script for the `db` demo executable.
 
@@ -22,5 +27,6 @@ make
 ./db
 ```
 
-The program will print the contents of a demo page and then list the tokens
-produced from a small SQL query.
+The program prints the contents of a demo page, tokenizes a query and then
+shows simple planning, execution, thread pool usage and authentication
+examples.

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -1,0 +1,29 @@
+#ifndef EXECUTOR_EXECUTOR_H
+#define EXECUTOR_EXECUTOR_H
+
+#include <stddef.h>
+#include "planner/planner.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TABLE_MAX_ROWS 1024
+#define ROW_SIZE 256
+
+typedef struct Table {
+    char name[32];
+    char rows[TABLE_MAX_ROWS][ROW_SIZE];
+    size_t row_count;
+} Table;
+
+void table_init(Table *table, const char *name);
+void table_insert(Table *table, const char *value);
+void table_select_all(const Table *table);
+void executor_execute(const Plan *plan, Table *table);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EXECUTOR_EXECUTOR_H */

--- a/include/parser/parser.h
+++ b/include/parser/parser.h
@@ -31,6 +31,7 @@ typedef enum TokenType {
     TOKEN_KEYWORD_INSERT,
     TOKEN_KEYWORD_INTO,
     TOKEN_KEYWORD_VALUES,
+    TOKEN_KEYWORD_FROM,
     TOKEN_UNKNOWN
 } TokenType;
 

--- a/include/planner/planner.h
+++ b/include/planner/planner.h
@@ -1,0 +1,29 @@
+#ifndef PLANNER_PLANNER_H
+#define PLANNER_PLANNER_H
+
+#include <stdbool.h>
+#include "parser/parser.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum PlanType {
+    PLAN_UNKNOWN,
+    PLAN_SELECT_ALL,
+    PLAN_INSERT_VALUE,
+} PlanType;
+
+typedef struct Plan {
+    PlanType type;
+    char table[32];
+    char value[256];
+} Plan;
+
+bool planner_plan(const char *query, Plan *out_plan);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PLANNER_PLANNER_H */

--- a/include/security/user.h
+++ b/include/security/user.h
@@ -1,0 +1,25 @@
+#ifndef SECURITY_USER_H
+#define SECURITY_USER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define USER_NAME_MAX 32
+
+typedef struct User {
+    char username[USER_NAME_MAX];
+    uint64_t password_hash;
+} User;
+
+void user_create(User *user, const char *username, const char *password);
+bool user_authenticate(const User *user, const char *username, const char *password);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECURITY_USER_H */

--- a/include/thread/thread_pool.h
+++ b/include/thread/thread_pool.h
@@ -1,0 +1,43 @@
+#ifndef THREAD_THREAD_POOL_H
+#define THREAD_THREAD_POOL_H
+
+#include <stddef.h>
+#include <pthread.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*TaskFunc)(void *arg);
+
+typedef struct Task {
+    TaskFunc func;
+    void *arg;
+} Task;
+
+#define TASK_QUEUE_SIZE 32
+
+typedef struct ThreadPool {
+    pthread_t *threads;
+    size_t thread_count;
+
+    Task queue[TASK_QUEUE_SIZE];
+    size_t head;
+    size_t tail;
+    size_t count;
+
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    bool shutdown;
+} ThreadPool;
+
+bool thread_pool_init(ThreadPool *pool, size_t thread_count);
+bool thread_pool_submit(ThreadPool *pool, TaskFunc func, void *arg);
+void thread_pool_shutdown(ThreadPool *pool);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* THREAD_THREAD_POOL_H */

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -1,0 +1,46 @@
+#include "executor/executor.h"
+#include <stdio.h>
+#include <string.h>
+
+void table_init(Table *table, const char *name)
+{
+    if (!table || !name)
+        return;
+    strncpy(table->name, name, sizeof(table->name) - 1);
+    table->name[sizeof(table->name) - 1] = '\0';
+    table->row_count = 0;
+}
+
+void table_insert(Table *table, const char *value)
+{
+    if (!table || !value || table->row_count >= TABLE_MAX_ROWS)
+        return;
+    strncpy(table->rows[table->row_count], value, ROW_SIZE - 1);
+    table->rows[table->row_count][ROW_SIZE - 1] = '\0';
+    table->row_count++;
+}
+
+void table_select_all(const Table *table)
+{
+    if (!table)
+        return;
+    printf("Table '%s' contents:\n", table->name);
+    for (size_t i = 0; i < table->row_count; i++)
+        printf("  %zu: %s\n", i + 1, table->rows[i]);
+}
+
+void executor_execute(const Plan *plan, Table *table)
+{
+    if (!plan || !table)
+        return;
+    switch (plan->type) {
+    case PLAN_INSERT_VALUE:
+        table_insert(table, plan->value);
+        break;
+    case PLAN_SELECT_ALL:
+        table_select_all(table);
+        break;
+    default:
+        break;
+    }
+}

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -77,6 +77,8 @@ Token parser_next_token(Parser *parser)
                 token.type = TOKEN_KEYWORD_INTO;
             else if (is_keyword(token.start, token.length, "VALUES"))
                 token.type = TOKEN_KEYWORD_VALUES;
+            else if (is_keyword(token.start, token.length, "FROM"))
+                token.type = TOKEN_KEYWORD_FROM;
             else
                 token.type = TOKEN_IDENTIFIER;
             return token;

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1,0 +1,65 @@
+#include "planner/planner.h"
+#include <string.h>
+
+/* Extremely small query planner that understands two forms:
+ * 1. SELECT * FROM <table>;
+ * 2. INSERT INTO <table> VALUES ('value');
+ */
+
+bool planner_plan(const char *query, Plan *out_plan)
+{
+    if (!query || !out_plan)
+        return false;
+    Parser parser;
+    parser_init(&parser, query);
+    Token tok = parser_next_token(&parser);
+
+    memset(out_plan, 0, sizeof(*out_plan));
+    out_plan->type = PLAN_UNKNOWN;
+
+    if (tok.type == TOKEN_KEYWORD_SELECT) {
+        tok = parser_next_token(&parser); /* expect '*' */
+        if (tok.type != TOKEN_STAR)
+            return false;
+        tok = parser_next_token(&parser); /* expect FROM */
+        if (tok.type != TOKEN_KEYWORD_FROM)
+            return false;
+        tok = parser_next_token(&parser); /* table name */
+        if (tok.type != TOKEN_IDENTIFIER)
+            return false;
+        size_t len = tok.length < sizeof(out_plan->table) - 1 ? tok.length : sizeof(out_plan->table) - 1;
+        strncpy(out_plan->table, tok.start, len);
+        out_plan->table[len] = '\0';
+        out_plan->type = PLAN_SELECT_ALL;
+        return true;
+    } else if (tok.type == TOKEN_KEYWORD_INSERT) {
+        tok = parser_next_token(&parser); /* expect INTO */
+        if (tok.type != TOKEN_KEYWORD_INTO)
+            return false;
+        tok = parser_next_token(&parser); /* table name */
+        if (tok.type != TOKEN_IDENTIFIER)
+            return false;
+        size_t len = tok.length < sizeof(out_plan->table) - 1 ? tok.length : sizeof(out_plan->table) - 1;
+        strncpy(out_plan->table, tok.start, len);
+        out_plan->table[len] = '\0';
+        tok = parser_next_token(&parser); /* VALUES */
+        if (tok.type != TOKEN_KEYWORD_VALUES)
+            return false;
+        tok = parser_next_token(&parser); /* LPAREN */
+        if (tok.type != TOKEN_LPAREN)
+            return false;
+        tok = parser_next_token(&parser); /* string or number */
+        if (tok.type != TOKEN_STRING && tok.type != TOKEN_NUMBER)
+            return false;
+        len = tok.length < sizeof(out_plan->value) - 1 ? tok.length : sizeof(out_plan->value) - 1;
+        strncpy(out_plan->value, tok.start, len);
+        out_plan->value[len] = '\0';
+        tok = parser_next_token(&parser); /* RPAREN */
+        if (tok.type != TOKEN_RPAREN)
+            return false;
+        out_plan->type = PLAN_INSERT_VALUE;
+        return true;
+    }
+
+    return false;
+}

--- a/src/security/user.c
+++ b/src/security/user.c
@@ -1,0 +1,33 @@
+#include "security/user.h"
+#include <string.h>
+
+/* Simple FNV-1a 64-bit hash for demonstration purposes. */
+static uint64_t fnv1a_hash(const char *str)
+{
+    const uint64_t fnv_offset = 14695981039346656037ULL;
+    const uint64_t fnv_prime = 1099511628211ULL;
+    uint64_t hash = fnv_offset;
+    for (const unsigned char *p = (const unsigned char*)str; *p; p++) {
+        hash ^= (uint64_t)(*p);
+        hash *= fnv_prime;
+    }
+    return hash;
+}
+
+void user_create(User *user, const char *username, const char *password)
+{
+    if (!user || !username || !password)
+        return;
+    strncpy(user->username, username, USER_NAME_MAX - 1);
+    user->username[USER_NAME_MAX - 1] = '\0';
+    user->password_hash = fnv1a_hash(password);
+}
+
+bool user_authenticate(const User *user, const char *username, const char *password)
+{
+    if (!user || !username || !password)
+        return false;
+    if (strncmp(user->username, username, USER_NAME_MAX) != 0)
+        return false;
+    return user->password_hash == fnv1a_hash(password);
+}

--- a/src/thread/thread_pool.c
+++ b/src/thread/thread_pool.c
@@ -1,0 +1,74 @@
+#include "thread/thread_pool.h"
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+static void *worker_main(void *arg)
+{
+    ThreadPool *pool = (ThreadPool*)arg;
+    for (;;) {
+        pthread_mutex_lock(&pool->mutex);
+        while (pool->count == 0 && !pool->shutdown)
+            pthread_cond_wait(&pool->cond, &pool->mutex);
+        if (pool->shutdown && pool->count == 0) {
+            pthread_mutex_unlock(&pool->mutex);
+            break;
+        }
+        Task task = pool->queue[pool->head];
+        pool->head = (pool->head + 1) % TASK_QUEUE_SIZE;
+        pool->count--;
+        pthread_mutex_unlock(&pool->mutex);
+        task.func(task.arg);
+    }
+    return NULL;
+}
+
+bool thread_pool_init(ThreadPool *pool, size_t thread_count)
+{
+    if (!pool || thread_count == 0 || thread_count > TASK_QUEUE_SIZE)
+        return false;
+    pool->threads = malloc(sizeof(pthread_t) * thread_count);
+    if (!pool->threads)
+        return false;
+    pool->thread_count = thread_count;
+    pool->head = pool->tail = pool->count = 0;
+    pool->shutdown = false;
+    pthread_mutex_init(&pool->mutex, NULL);
+    pthread_cond_init(&pool->cond, NULL);
+    for (size_t i = 0; i < thread_count; i++)
+        pthread_create(&pool->threads[i], NULL, worker_main, pool);
+    return true;
+}
+
+bool thread_pool_submit(ThreadPool *pool, TaskFunc func, void *arg)
+{
+    if (!pool || !func)
+        return false;
+    pthread_mutex_lock(&pool->mutex);
+    if (pool->count == TASK_QUEUE_SIZE) {
+        pthread_mutex_unlock(&pool->mutex);
+        return false; /* queue full */
+    }
+    pool->queue[pool->tail].func = func;
+    pool->queue[pool->tail].arg = arg;
+    pool->tail = (pool->tail + 1) % TASK_QUEUE_SIZE;
+    pool->count++;
+    pthread_cond_signal(&pool->cond);
+    pthread_mutex_unlock(&pool->mutex);
+    return true;
+}
+
+void thread_pool_shutdown(ThreadPool *pool)
+{
+    if (!pool)
+        return;
+    pthread_mutex_lock(&pool->mutex);
+    pool->shutdown = true;
+    pthread_cond_broadcast(&pool->cond);
+    pthread_mutex_unlock(&pool->mutex);
+    for (size_t i = 0; i < pool->thread_count; i++)
+        pthread_join(pool->threads[i], NULL);
+    free(pool->threads);
+    pthread_mutex_destroy(&pool->mutex);
+    pthread_cond_destroy(&pool->cond);
+}


### PR DESCRIPTION
## Summary
- implement a tiny query planner and executor
- add simple thread pool utility
- add user authentication helpers
- extend main demo to show new features
- update docs and build system for new modules

## Testing
- `make`
- `./db`

------
https://chatgpt.com/codex/tasks/task_e_68779bb39ba883218b00b8c0e487b0a5