### PR TITLE
Add CLI interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC ?= gcc
 CFLAGS ?= -Wall -Wextra -std=c11 -Iinclude -pthread
 
-SRC := $(wildcard src/*.c src/storage/*.c src/parser/*.c src/planner/*.c src/executor/*.c src/thread/*.c src/security/*.c)
+SRC := $(wildcard src/*.c src/storage/*.c src/parser/*.c src/planner/*.c src/executor/*.c src/cli/*.c src/thread/*.c src/security/*.c)
 OBJ := $(SRC:.c=.o)
 TARGET := db
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ The executable demonstrates usage of the storage layer, a small SQL tokenizer
 and newly added components including a minimal query planner and executor,
 a thread pool and a simple user authentication module.
 
+After these examples run, the program starts a very small interactive
+command line interface. You can enter SQL statements such as
+`SELECT * FROM table1;` or `INSERT INTO table1 VALUES ('abc');` and type
+`quit` to exit.
+
 ## Running with Docker
 
 Build the Docker image and run the demo executable inside a container:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -29,4 +29,5 @@ make
 
 The program prints the contents of a demo page, tokenizes a query and then
 shows simple planning, execution, thread pool usage and authentication
-examples.
+examples. After these demonstrations, an interactive command line interface
+starts so you can experiment with your own SQL statements. Type `quit` to exit.

--- a/include/cli/cli.h
+++ b/include/cli/cli.h
@@ -1,0 +1,21 @@
+#ifndef CLI_CLI_H
+#define CLI_CLI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "executor/executor.h"
+
+/* Run an interactive command-line interface allowing users to submit
+ * simple SQL statements. Supported statements are the same as the
+ * planner and executor modules: SELECT * FROM <table>; and
+ * INSERT INTO <table> VALUES ('value');
+ */
+void cli_run(Table *table);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CLI_CLI_H */

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -1,0 +1,29 @@
+#include "cli/cli.h"
+#include "planner/planner.h"
+#include <stdio.h>
+#include <string.h>
+
+void cli_run(Table *table)
+{
+    if (!table)
+        return;
+
+    char line[512];
+    printf("Enter SQL statements or 'quit' to exit.\n");
+    while (1) {
+        printf("db> ");
+        fflush(stdout);
+        if (!fgets(line, sizeof(line), stdin))
+            break;
+        line[strcspn(line, "\n")] = '\0';
+        if (strcmp(line, "quit") == 0 || strcmp(line, "exit") == 0)
+            break;
+        if (line[0] == '\0')
+            continue;
+        Plan plan;
+        if (planner_plan(line, &plan))
+            executor_execute(&plan, table);
+        else
+            printf("Error: could not parse input.\n");
+    }
+}

--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,7 @@
 #include "parser/parser.h"
 #include "planner/planner.h"
 #include "executor/executor.h"
+#include "cli/cli.h"
 #include "thread/thread_pool.h"
 #include "security/user.h"
 
@@ -86,6 +87,9 @@ int main(void)
 
     if (planner_plan(select_q, &plan))
         executor_execute(&plan, &table);
+
+    /* Start interactive CLI */
+    cli_run(&table);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- implement a basic interactive CLI
- compile CLI sources
- integrate the CLI into the demo program
- document usage in README and project overview

## Testing
- `make clean`
- `make`
- `./db <<EOF
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6878d4c4d4f4832197673a6f7008c152