### PR TITLE
Improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ make
 
 The executable demonstrates usage of the storage layer, a small SQL tokenizer
 and newly added components including a minimal query planner and executor,
-a thread pool and a simple user authentication module.
+a thread pool and a simple user authentication module. Basic error handling
+now reports failures such as thread pool initialization problems to STDERR.
 
 After these examples run, the program starts a very small interactive
 command line interface. You can enter SQL statements such as

--- a/src/thread/thread_pool.c
+++ b/src/thread/thread_pool.c
@@ -27,16 +27,43 @@ bool thread_pool_init(ThreadPool *pool, size_t thread_count)
 {
     if (!pool || thread_count == 0 || thread_count > TASK_QUEUE_SIZE)
         return false;
+
     pool->threads = malloc(sizeof(pthread_t) * thread_count);
-    if (!pool->threads)
+    if (!pool->threads) {
+        fprintf(stderr, "thread_pool_init: failed to allocate thread array\n");
         return false;
+    }
+
     pool->thread_count = thread_count;
     pool->head = pool->tail = pool->count = 0;
     pool->shutdown = false;
-    pthread_mutex_init(&pool->mutex, NULL);
-    pthread_cond_init(&pool->cond, NULL);
-    for (size_t i = 0; i < thread_count; i++)
-        pthread_create(&pool->threads[i], NULL, worker_main, pool);
+
+    if (pthread_mutex_init(&pool->mutex, NULL) != 0) {
+        fprintf(stderr, "thread_pool_init: mutex init failed\n");
+        free(pool->threads);
+        return false;
+    }
+
+    if (pthread_cond_init(&pool->cond, NULL) != 0) {
+        fprintf(stderr, "thread_pool_init: cond init failed\n");
+        pthread_mutex_destroy(&pool->mutex);
+        free(pool->threads);
+        return false;
+    }
+
+    for (size_t i = 0; i < thread_count; i++) {
+        if (pthread_create(&pool->threads[i], NULL, worker_main, pool) != 0) {
+            fprintf(stderr, "thread_pool_init: failed to create thread\n");
+            pool->shutdown = true;
+            for (size_t j = 0; j < i; j++)
+                pthread_join(pool->threads[j], NULL);
+            pthread_cond_destroy(&pool->cond);
+            pthread_mutex_destroy(&pool->mutex);
+            free(pool->threads);
+            return false;
+        }
+    }
+
     return true;
 }
 
@@ -44,10 +71,11 @@ bool thread_pool_submit(ThreadPool *pool, TaskFunc func, void *arg)
 {
     if (!pool || !func)
         return false;
+
     pthread_mutex_lock(&pool->mutex);
-    if (pool->count == TASK_QUEUE_SIZE) {
+    if (pool->shutdown || pool->count == TASK_QUEUE_SIZE) {
         pthread_mutex_unlock(&pool->mutex);
-        return false; /* queue full */
+        return false; /* queue full or shutting down */
     }
     pool->queue[pool->tail].func = func;
     pool->queue[pool->tail].arg = arg;
@@ -61,6 +89,8 @@ bool thread_pool_submit(ThreadPool *pool, TaskFunc func, void *arg)
 void thread_pool_shutdown(ThreadPool *pool)
 {
     if (!pool)
+        return;
+    if (!pool->threads)
         return;
     pthread_mutex_lock(&pool->mutex);
     pool->shutdown = true;


### PR DESCRIPTION
## Summary
- check thread pool initialization for allocation and thread creation failures
- handle queue full and shutdown cases when submitting tasks
- guard thread_pool_shutdown when threads are missing
- report initialization and planning failures in `main`
- document new error reporting behavior in README

## Testing
- `make clean && make`
- `./db <<'EOF'
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6878daf89d1c83218bac1188bd691db0